### PR TITLE
Un-needed return statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
 module.exports = function(a) {
-	if(typeof(a) == 'undefined') return true;
-	else return false;
-}
+	return a === undefined;
+};


### PR DESCRIPTION
The implementation of isUndefined is over complicated for it's need, a simple return statement suffices.
